### PR TITLE
Hacky fix for Meteoswiss interface changes

### DIFF
--- a/hamsclient/client.py
+++ b/hamsclient/client.py
@@ -11,6 +11,7 @@ import re
 _LOGGER = logging.getLogger(__name__)
 
 MS_BASE_URL = 'https://www.meteosuisse.admin.ch'
+JSON_FORECAST_URL = 'https://app-prod-ws.meteoswiss-app.ch/v1/forecast?plz={}00&graph=false&warning=true'
 MS_SEARCH_URL = 'https://www.meteosuisse.admin.ch/home/actualite/infos.html?ort={}&pageIndex=0&tab=search_tab'
 CURRENT_CONDITION_URL= 'https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/VQHA80.csv'
 STATION_URL = "https://data.geo.admin.ch/ch.meteoschweiz.messwerte-aktuell/info/VQHA80_fr.txt"
@@ -28,6 +29,8 @@ class meteoSwissClient():
         
     
     def get_data(self):
+        self.get_forecast()
+        self.get_current_condition()
         return  {"name": self._name,"forecast": self._forecast, "condition":self._condition}
 
     def get_24hforecast(self):
@@ -63,20 +66,9 @@ class meteoSwissClient():
         #Forcing headers to avoid 500 error when downloading file
         s.headers.update({"Accept":"text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
                     "Accept-Encoding":"gzip, deflate, sdch",'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/1337 Safari/537.36'})
-        searchUrl = MS_SEARCH_URL.format(self._postCode)
-        _LOGGER.debug("Main URL : %s"%searchUrl)
-        tmpSearch = s.get(searchUrl,timeout=10)
 
-        soup = BeautifulSoup(tmpSearch.text,features="html.parser")
-        widgetHtml = soup.find_all("section",{"id": "weather-widget"})
-        jsonUrl = widgetHtml[0].get("data-json-url")
-        jsonDataFile = str.split(jsonUrl,'/')[-1]
-        newJsonDataFile = str(self._postCode)+"00.json"
-        jsonUrl = str(jsonUrl).replace(jsonDataFile,newJsonDataFile)
-        dataUrl = MS_BASE_URL + jsonUrl
-        _LOGGER.debug("Data URL : %s"%dataUrl)
-        s.headers.update({'referer': searchUrl})
-        jsonData = s.get(dataUrl,timeout=10)
+        jsonUrl = JSON_FORECAST_URL.format(self._postCode)
+        jsonData = s.get(jsonUrl,timeout=10)
         jsonDataTxt = jsonData.text
 
         jsonObj = json.loads(jsonDataTxt)
@@ -86,9 +78,9 @@ class meteoSwissClient():
 
     def get_current_condition(self):
         _LOGGER.debug("Update current condition")
-        data = pd.read_csv(CURRENT_CONDITION_URL,sep=';',header=1)
+        data = pd.read_csv(CURRENT_CONDITION_URL,sep=';')
         _LOGGER.debug("Get current condition for : %s"%self._station)
-        stationData = data.loc[data['stn'].str.contains(self._station)]
+        stationData = data.loc[data['Station/Location'].str.contains(self._station)]
         stationData = stationData.to_dict('records')
         self._condition =  stationData
     
@@ -195,3 +187,7 @@ class meteoSwissClient():
         return "N"
 
                 
+# a = meteoSwissClient("Thun", "3604", "THU")
+# a.get_forecast()
+# a.get_current_condition()
+# a.get_data()


### PR DESCRIPTION
Hacked this up quickly to show what's be broken by the recent meteoswiss API changes. Together with https://github.com/websylv/homeassistant-meteoswiss/pull/55 has got things working again on my install for my postcode at least!

@websylv thanks for the great work! Are you still maintaining this? 

If anyone sees this and wants to try get theirs going, you can try drop the contents of this `client.py` into your HA install, somewhere like `/config/deps/lib/python3.9/site-packages/hamsclient/client.py`, and restart HA. You will need to do the same sort of thing with the weather.py from the other linked PR. It's late and I haven't tested this extensively so please only do this somewhere non-productionish!
